### PR TITLE
Add Storage Legacy Bucket Reader permission instructions 

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -42,7 +42,7 @@ Pass a list of env vars as build-args for docker-build, separated by commas. ie:
 
 ## Permissions
 The service key you provided must have the `Storage Admin` permission to push the image to GCR.
-It is possible to use a lower access level `Storage Object Admin`, but it will work only for already created registry. 
+It is possible to use a lower access level `Storage Object Admin`, but it will work only for already created registry. You must also add the `Storage Legacy Bucket Reader` permission to the `artifacts.<project id>.appspot.com` bucket for the given service account.
 
 [Reference 1](https://cloud.google.com/container-registry/docs/access-control)
 


### PR DESCRIPTION
After the registry has been created, when the `Storage Object Admin` permission is used by itself, the following error is raised:

```bash
denied: Token exchange failed for project '***'. Caller does not have permission 'storage.buckets.get'. To configure permissions, follow instructions at: https://cloud.google.com/container-registry/docs/access-control
```

To fix this, the `Storage Legacy Bucket Reader` permission should be added to the `artifacts.<project id>.appspot.com` bucket for the service account that is being used.